### PR TITLE
Make flash messages work for route resources

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -6,9 +6,11 @@ Ember.Route.reopen(
     var controller = this.controllerFor('flashMessage'),
         routeName = this.get('routeName');
 
+    var target = this.get('router.router.activeTransition.targetName');
+
     // do not display message in loading route, wait until
     // any loading is done.
-    if (routeName !== "loading") {
+    if (routeName !== "loading" && routeName === target) {
       controller.now();
     }
   }

--- a/tests/integration/flash_message_test.js
+++ b/tests/integration/flash_message_test.js
@@ -6,6 +6,9 @@ App.Router.map(function() {
   this.route('page1');
   this.route('page2');
   this.route('promise');
+  this.resource('posts', { path: '/posts' }, function() {
+    this.route('new');
+  });
 });
 
 App.PromiseRoute = Ember.Route.extend({
@@ -118,6 +121,18 @@ test("should display the flash message instantly", function() {
   andThen(function() {
     router().flashMessage('instant message').now();
   });
+
+  andThen(assertMessage);
+});
+
+test("should display the flash message for resource", function() {
+  visit("/");
+
+  andThen(function() {
+    router().flashMessage('test');
+  });
+
+  visit("/posts/new");
 
   andThen(assertMessage);
 });


### PR DESCRIPTION
Hi there,
I realised that when setting a flash message and then transitioning into a route defined as resource, the flash message is lost.

``` javascript
App.Router.map(function() {
  this.resource('posts', { path: '/posts' }, function() {
    this.route('new');
  });
});
```

``` javascript
this.flashMessage("Create a new post");
this.transitionTo('posts.new');
```

For whatever reason the "activate" hook is called twice.(Probably once for PostsRoute, and once for PostNewRoute in the example above).

The first time it is called with _routeName_ "post", second time with "post.new". 

The problem is, that the first time the hook is called the message gets set, so on the second time it is lost. I fixed it by comparing the _routeName_ to the transition's _targetName_.
