### PR TITLE
Adding ability to pass in a className

### DIFF
--- a/lib/route_mixin.js
+++ b/lib/route_mixin.js
@@ -1,8 +1,16 @@
 Ember.FlashMessageRouteMixin = Ember.Mixin.create({
-  flashMessage: function(message) {
+  flashMessage: function(message, messageType) {
     var controller = this.controllerFor('flashMessage');
 
-    controller.set('queuedMessage', message);
+    var messageObject = Ember.Object.create({
+      text: message
+    });
+
+    if(typeof messageType !== 'undefined') {
+      messageObject.set('type', messageType);
+    }
+
+    controller.set('queuedMessage', messageObject);
 
     return controller;
   }

--- a/tests/integration/flash_message_test.js
+++ b/tests/integration/flash_message_test.js
@@ -35,10 +35,14 @@ App.FromControllerController = Ember.Controller.extend({
   }
 });
 
-Ember.TEMPLATES.application = Ember.Handlebars.compile('{{#flashMessage}}<span class="message">{{message}}</span>{{/flashMessage}}');
+Ember.TEMPLATES.application = Ember.Handlebars.compile('{{#flashMessage}}<span {{bind-attr class=":message message.type"}}>{{message.text}}</span>{{/flashMessage}}');
 
 var findMessage = function() {
   return $('#qunit-fixture .message');
+};
+
+var hasClass = function(className) {
+  return $('#qunit-fixture .message').hasClass(className);
 };
 
 var messageExists = function() {
@@ -96,6 +100,25 @@ test("should see a flash message when I transition to the next route", function(
 
   andThen(function() {
     equal(findMessage().text().trim(), 'hello world');
+  });
+});
+
+test("should have a message object with text and type defined", function() {
+  expect(3);
+
+  visit('/');
+
+  andThen(function() {
+    router().flashMessage('Happy Message', 'success');
+  });
+
+  visit("/page1");
+
+  andThen(assertMessage);
+
+  andThen(function() {
+    equal(findMessage().text().trim(), 'Happy Message');
+    ok(hasClass('success'));
   });
 });
 


### PR DESCRIPTION
This is an enhancement for issue #10. I've added a test and everything is green on my machine.

The biggest change here is that messages are now objects, rather than simple strings. This allows us to attach extra information to them. As an example:

```
// flashMessage now accepts a message and a second (optional) type.
router().flashMessage('Happy Message', 'success');

{{#flashMessage}}
    <span {{bind-attr class=":message message.type"}}>{{message.text}}</span>
{{/flashMessage}}
```

Let me know if you want anything done differently. Thanks for the great library! :heart_eyes: 
