### PR TITLE
Render a custom template as flash, with an associated controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,52 @@ App.PostController = Ember.ObjectController.extend({
 Please note that whenever you set the flash message from a control it
 will be displayed instantly.
 
+### Using flash templates instead of text messages
+
+In case you believe flash is a "view" thing, or if you need to use
+different markup through your messages (custom actions, images...),
+you can define your flash messages in templates, and render them
+using a specific controller.
+
+Example from a route:
+
+```javascript
+Ember.ProfileRoute = Ember.Route.extend({
+  setupController: function(controller, profile) {
+    if(profile.isEmpty()) {
+      this.flash({
+        templateName: 'emptyProfileNotice',
+        controller: controller,
+      });
+    }
+    this._super(controller, profile);
+  },
+});
+```
+
+Example from a controller:
+
+```javascript
+App.PostController = Ember.ObjectController.extend({
+  needs: ['flashMessage'],
+
+  actions: {
+    save: function() {
+      var flashMessage = this.get('controllers.flashMessage');
+      var controller = this;
+
+      this.get('model').save()
+        .then(function() {
+          flashMessage.set('message', Ember.Object.create({
+            templateName: 'savedPostNotice',
+            controller: controller,
+          });
+        });
+    }
+  }
+});
+```
+
 ## Development
 
 This plugin is built with rake pipeline, which requires Ruby. To get

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -9,9 +9,20 @@ Ember.Handlebars.registerHelper('flashMessage', function(options) {
               view;
 
           if (currentMessage) {
-            view = Ember.View.create({
-              template: template
-            });
+            if (currentMessage.get && currentMessage.get('templateName')) {
+              var customTemplateName = currentMessage.get('templateName'),
+                  customTemplateController = currentMessage.get('controller');
+
+              view = Ember.View.create({
+                templateName: customTemplateName,
+                controller: customTemplateController,
+              });
+            }
+            else {
+              view = Ember.View.create({
+                template: template
+              });
+            }
           }
 
           this.set('currentView', view);

--- a/lib/route_mixin.js
+++ b/lib/route_mixin.js
@@ -13,5 +13,18 @@ Ember.FlashMessageRouteMixin = Ember.Mixin.create({
     controller.set('queuedMessage', messageObject);
 
     return controller;
-  }
+  },
+
+  flash: function(options) {
+    var controller = this.controllerFor('flashMessage');
+
+    var messageObject = Ember.Object.create({
+      templateName: options.templateName,
+      controller: options.controller
+    });
+
+    controller.set('queuedMessage', messageObject);
+
+    return controller;
+  },
 });


### PR DESCRIPTION
This PR allows you to define flash messages in templates, and to render them with whatever controller you want.

This has some advantages:
- You can put custom markup in your templates: images, titles, links...
- You can bind some template tags to custom controller actions (e.g. "undo")
- If you think flash is a "view" thing (as I do), you can move it from the control layer to the view one
- You can still put a simple text message with some helper handling all the default markup

Of course, the text-oriented API still works.

I have a working implementation, but it may deserve some refactoring:
- Extract a message model, maybe with some `isTextMessage()` method?
- Maybe find a better name to the `flash()` method... `flashTemplate()`? Any idea?
- DRY the route mixin
- Don't have to create a custom object when calling from a controller... by providing some mixin too?

WDYT?
